### PR TITLE
AASM 4.3 0 - 4.9.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ to write it like that:
       super
       # your own code
     end
+    
+## Compatibility
+
+Version 0.2.0 of this gem is compatible with aasm gem versions 4.3.0 - 4.9.0, except using inherited Ohm::Model 
+classes with state_machine defined on superclass.
 
 ## Contributing
 

--- a/aasm_ohm_persistence.gemspec
+++ b/aasm_ohm_persistence.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'aasm', '>= 4.3.0, < 4.10.0'
   spec.add_dependency "ohm-contrib"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/aasm/persistence/ohm_persistence.rb
+++ b/lib/aasm/persistence/ohm_persistence.rb
@@ -60,14 +60,14 @@ module AASM
         #
         # NOTE: intended to be called from an event
 
-        def aasm_write_state(state)
-          old_value = self.send(self.class.aasm_column.to_sym)
-          aasm_write_state_without_persistence(state)
+        def aasm_write_state(state, name = :default)
+          old_value = self.send(self.class.aasm(name).attribute_name)
+          aasm_write_state_without_persistence(state, name)
 
           success = self.save
 
           unless success
-            aasm_write_state_without_persistence(old_value)
+            aasm_write_state_without_persistence(old_value, name)
             return false
           end
 
@@ -86,8 +86,8 @@ module AASM
         #   Foo.find(1).aasm.current_state # => :closed
         #
         # NOTE: intended to be called from an event
-        def aasm_write_state_without_persistence(state)
-          self.send(:"#{self.class.aasm_column}=", state.to_s)
+        def aasm_write_state_without_persistence(state, name = :default)
+          self.send(:"#{self.class.aasm(name).attribute_name}=", state.to_s)
         end
 
       private

--- a/lib/aasm/persistence/ohm_persistence.rb
+++ b/lib/aasm/persistence/ohm_persistence.rb
@@ -98,10 +98,13 @@ module AASM
         #   foo.aasm_state # => nil
         #
         def aasm_ensure_initial_state
-          aasm.enter_initial_state if send(self.class.aasm_column).blank?
+          AASM::StateMachine[self.class].keys.each do |state_machine_name|
+            next if send(self.class.aasm(state_machine_name).attribute_name).present?
+            send("#{self.class.aasm(state_machine_name).attribute_name}=",
+                 aasm(state_machine_name).enter_initial_state.to_s)
+          end
         end
       end # InstanceMethods
     end
   end
 end
-

--- a/lib/aasm/persistence/ohm_persistence.rb
+++ b/lib/aasm/persistence/ohm_persistence.rb
@@ -29,7 +29,6 @@ module AASM
       #
       def self.included(base)
         base.send(:include, AASM::Persistence::Base)
-        base.extend AASM::Persistence::OhmPersistence::ClassMethods
         base.send(:include, Ohm::Callbacks)
         base.send(:include, AASM::Persistence::OhmPersistence::InstanceMethods)
       end

--- a/lib/aasm/persistence/ohm_persistence.rb
+++ b/lib/aasm/persistence/ohm_persistence.rb
@@ -34,16 +34,6 @@ module AASM
         base.send(:include, AASM::Persistence::OhmPersistence::InstanceMethods)
       end
 
-      module ClassMethods
-        def find_in_state(id, state, *args)
-          find(aasm_column.to_sym => state)[id]
-        end
-
-        def count_in_state(state, *args)
-          find(aasm_column.to_sym => state).count
-        end
-      end
-
       module InstanceMethods
         def before_create
           super

--- a/lib/aasm_ohm_persistence/version.rb
+++ b/lib/aasm_ohm_persistence/version.rb
@@ -1,3 +1,3 @@
 module AasmOhmPersistence
-  VERSION = "0.0.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Hi, @phuongnd08 !

Here's a PR to enable compatibility with AASM 4.3 0 - 4.9.0 versions. Need to note, though, that these aasm versions wouldn't work with inherited Ohm::Model classes

Changed `aasm_write_state_without_persistence` and `aasm_write_state` methods' signatures to accept `name` parameter with `:default ` value.

Changed `aasm_ensure_initial_state` method to iterate all possibly defined multiple state_machines.

Removed unused `find_in_state` and `count_in_state` class methods.